### PR TITLE
Attempt to maintain fg/bg consitency between rows and tiles when importing map image in bitmap mode

### DIFF
--- a/src/com/dreamcodex/ti/importers/MapImageFileImporter.java
+++ b/src/com/dreamcodex/ti/importers/MapImageFileImporter.java
@@ -392,7 +392,7 @@ public class MapImageFileImporter extends Importer {
                 if (backColor == foreColor && foreColor != screenColor) {
                     backColor = screenColor;
                 }
-                else if (foreColor == screenColor || lastBackColor == foreColor || lastForeColor == backColor) {
+                else if (backColor != screenColor && (foreColor == screenColor || lastBackColor == foreColor || lastForeColor == backColor)) {
                     int tmp = foreColor;
                     foreColor = backColor;
                     backColor = tmp;
@@ -400,6 +400,7 @@ public class MapImageFileImporter extends Importer {
 
                 lastBackColor = backColor;
                 lastForeColor = foreColor;
+
                 charColors[y][Globals.INDEX_CLR_BACK] = backColor;
                 charColors[y][Globals.INDEX_CLR_FORE] = foreColor;
                 // Pattern

--- a/src/com/dreamcodex/ti/importers/MapImageFileImporter.java
+++ b/src/com/dreamcodex/ti/importers/MapImageFileImporter.java
@@ -372,6 +372,8 @@ public class MapImageFileImporter extends Importer {
     }
 
     private void importBitmapMode(ArrayList<Pattern> patterns) {
+        int lastBackColor = 0;
+        int lastForeColor = 0;
         for (int i = 0; i < patterns.size() && i <= maxIndex; i++) {
             int[][] rgbGrid = patterns.get(i).getRgbGrid();
             int[][] charGrid = this.charGrids.computeIfAbsent(i + startIndex, k -> new int[8][8]);
@@ -390,11 +392,14 @@ public class MapImageFileImporter extends Importer {
                 if (backColor == foreColor && foreColor != screenColor) {
                     backColor = screenColor;
                 }
-                else if (foreColor == screenColor) {
+                else if (foreColor == screenColor || lastBackColor == foreColor || lastForeColor == backColor) {
                     int tmp = foreColor;
                     foreColor = backColor;
                     backColor = tmp;
                 }
+
+                lastBackColor = backColor;
+                lastForeColor = foreColor;
                 charColors[y][Globals.INDEX_CLR_BACK] = backColor;
                 charColors[y][Globals.INDEX_CLR_FORE] = foreColor;
                 // Pattern


### PR DESCRIPTION
The previous foreground and background color is kept and compared against the new row.

If the new row's background color doesn't match the screen color and the current row's foreground color matches the previous row's background color or vice-versa, the foreground and background of the current row are swapped to help maintain a consistent color mapping within the tile (and even between adjacent tiles).

This change doesn't affect the attempt Magellan makes to keep the background color matching the project background.